### PR TITLE
[PKG-15854] databricks-sdk 0.104.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "databricks-sdk" %}
-{% set version = "0.117.0" %}
+{% set version = "0.104.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,9 +7,9 @@ package:
 
 source:
   - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-    sha256: 30a6fc21a8f9c4a41830c43332ae63b38c3679a83ac1bda4734ce7ced114faf1
+    sha256: 527c35aac3a28665a7933f34b7dd0c1bd6e9450a487f2c02fcfb6dce72ca82c9
   - url: https://github.com/databricks/{{ name }}-py/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: ae320849a1e6614afb4746d9b64751175c72a71fc3233a2fff3f6ded844735f3
+    sha256: 7ecfea77ed0aada6e436d314416812151ed84d1a47795762bf8fcf701e3921fb
     folder: gh_src
 
 build:
@@ -28,7 +28,6 @@ requirements:
     - requests >=2.28.1,<3
     - google-auth >=2.0,<3
     - protobuf >=4.25.8,!=5.26.*,!=5.27.*,!=5.28.*,!=5.29.0,!=5.29.1,!=5.29.2,!=5.29.3,!=5.29.4,!=6.30.0,!=6.30.1,!=6.31.0,<7.0
-    - urllib3 >=1.26,<3
   run_constrained:
     - ipython >=8,<10
     - ipywidgets >=8,<9
@@ -38,8 +37,6 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_langchain_open_ai_client" %}
 {% set tests_to_skip = tests_to_skip + " or test_get_open_ai_client_deprecation_warning" %}
 {% set tests_to_skip = tests_to_skip + " or test_get_langchain_chat_open_ai_client_deprecation_warning" %}
-{% set tests_to_skip = tests_to_skip + " or test_resolve_cli_command_dev_build_logs_info_and_falls_back" %}
-{% set tests_to_skip = tests_to_skip + " or test_resolve_cli_command_malformed_version_json_falls_back" %}
 test:
   source_files:
     - gh_src/tests
@@ -59,9 +56,6 @@ test:
     # test_init_file_contents: verifies hash of databricks/__init__.py, not relevant for us.
     # test_open_ai_client, test_langchain_open_ai_client, test_get_open_ai_client_deprecation_warning,
     # test_get_langchain_chat_open_ai_client_deprecation_warning: require openai/httpx optional deps not installed.
-    # test_resolve_cli_command_dev_build_logs_info_and_falls_back,
-    # test_resolve_cli_command_malformed_version_json_falls_back: rely on caplog capturing
-    # internal SDK logger messages; log propagation is not reliable in our test environment.
     - pytest tests -vv -m "not integration and not benchmark" -k "not ({{ tests_to_skip }})"
 
 about:


### PR DESCRIPTION
## Downgrade to 0.104.0 from databricks-sdk-feedstock

### Links
- [PKG-15854](https://anaconda.atlassian.net/browse/PKG-15854) — databricks-sdk 0.104.0
- [databricks-sdk-py dev](https://github.com/databricks/databricks-sdk-py/tree/v0.104.0)
- [conda-forge recipe](https://github.com/conda-forge/databricks-sdk-feedstock)
- [PyPI](https://pypi.org/project/databricks-sdk/0.104.0/)
- [PyPI Inspector](https://inspector.pypi.io/project/databricks-sdk/0.104.0/)

### Changes
- `recipe/meta.yaml`: downgrade version `0.117.0` → `0.104.0`, update sha256 hashes, remove `urllib3` run dep (not required in 0.104.0), trim `tests_to_skip` (`test_resolve_cli_command_*` don't exist in v0.104.0)

### Notes
- Downgrade required as a dependency for `dbt-databricks`
- PR targets `main-0.104.0` versioned branch

[PKG-15854]: https://anaconda.atlassian.net/browse/PKG-15854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ